### PR TITLE
Change Map to Keyword for reading options and default options

### DIFF
--- a/lib/ueberauth/strategy/line.ex
+++ b/lib/ueberauth/strategy/line.ex
@@ -143,10 +143,10 @@ defmodule Ueberauth.Strategy.Line do
   defp option(conn, key) do
     default =
       default_options()
-      |> Map.get(key)
+      |> Keyword.get(key)
 
     conn
     |> options
-    |> Map.get(key, default)
+    |> Keyword.get(key, default)
   end
 end


### PR DESCRIPTION
Fix error `expected a map, got: [default_scope: "", profile_fields: "", uid_field: :userId, allowed_request_params: [:auth_type]]`